### PR TITLE
Preserve spaces in arguments

### DIFF
--- a/suod.sh
+++ b/suod.sh
@@ -10,4 +10,4 @@ insults=(
 
 num_insults=${#insults[@]}
 echo ${insults[$(($RANDOM % num_insults))]}
-sudo $@
+sudo "$@"


### PR DESCRIPTION
Otherwise, e.g. `suod cat "/root/my file"` would break